### PR TITLE
Remove src directory from .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,3 @@
 examples
 example
 dev
-src


### PR DESCRIPTION
This may spawn some discussion but I personally find it useful when NPM packages include the sources. Not only does it help with debugging, but projects with their own ES build pipelines can choose to consume the source files directly rather than the pre-transpiled results.