### PR TITLE
Specify directory for types

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "module": "dist/index.es.js",
   "jsnext:main": "dist/index.es.js",
   "style": "dist/index.css",
-  "types": "index.d.ts",
+  "types": "dist/index.d.ts",
   "author": "Claus Wahlers <claus@codeazur.com.br> (https://github.com/claus)",
   "contributors": [
     {


### PR DESCRIPTION
Without this, TypeScript will not be able to find the definition.