### PR TITLE
exports: false breaks node module loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "4.0.3",
   "description": "dat.GUI reimagined for React",
   "main": "dist/index.cjs.js",
-  "exports": false,
+  "exports": "./dist/index.cjs.js",
   "module": "dist/index.es.js",
   "jsnext:main": "dist/index.es.js",
   "style": "dist/index.css",


### PR DESCRIPTION
See https://github.com/nodejs/node/issues/32107#issuecomment-642361654

This breaks the module loader on versions newer than node 12.16.x