### PR TITLE
Include css in package.json exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "4.1.1",
   "description": "dat.GUI reimagined for React",
   "main": "dist/index.cjs.js",
-  "exports": "./dist/index.cjs.js",
+  "exports": {
+    ".": "./dist/index.cjs.js",
+    "./dist/index.css": "./dist/index.css"
+  },
   "module": "dist/index.es.js",
   "jsnext:main": "dist/index.es.js",
   "style": "dist/index.css",


### PR DESCRIPTION
This fixes importing `react-dat-gui/dist/index.css` when using esbuild as a bundler.